### PR TITLE
Allow nested object structure in mapDispatchToProps

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -127,10 +127,10 @@ function connectStateAndProps(mapStateToProps, mapDispatchToProps, params, ownPr
 function asPromise(actions, props) {
   return Object.keys(actions).reduce(
     (host, key) => Object.assign(host, {
-      [key]: (...args) => {
+      [key]: typeof actions[key] === 'function' ? (...args) => {
         actions[key](...args);
         return later(props);
-      },
+      } : asPromise(actions[key], props),
     }), {}
   );
 }

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -173,6 +173,28 @@ describe('wire components', () => {
       expect(logger.log).toHaveBeenCalledWith('do it');
     });
   });
+
+  it('mocks nested objects in mapDispatchToProps', () => {
+    const mockedApi = jest.fn(() => Promise.resolve());
+    const { functions } = wire({
+      sagas: [sagas],
+      component: {
+        mapDispatchToProps: (dispatch) => ({
+          actions: {
+            load: (url) => dispatch(load(url)),
+          }
+        }),
+      },
+      mocks: [
+        [fetch, mockedApi],
+      ],
+    });
+
+    return functions.actions.load('test url').then((props) => {
+      expect(mockedApi).toHaveBeenCalledWith('test url');
+      expect(logger.log).toHaveBeenCalledWith('do it');
+    });
+  });
 });
 
 describe('structuredMocks', () => {


### PR DESCRIPTION
If mapDispatchToProps returns an object, the asPromise function wraps the nested functions instead of the object itself